### PR TITLE
Added "Load Single Prompt From File" which loads the prompt with the given index

### DIFF
--- a/inspire/prompt_support.py
+++ b/inspire/prompt_support.py
@@ -138,6 +138,63 @@ class LoadPromptsFromFile:
         return (prompts, )
 
 
+class LoadSinglePromptFromFile:
+    @classmethod
+    def INPUT_TYPES(cls):
+        global prompts_path
+        try:
+            prompt_files = []
+            for root, dirs, files in os.walk(prompts_path):
+                for file in files:
+                    if file.endswith(".txt"):
+                        file_path = os.path.join(root, file)
+                        rel_path = os.path.relpath(file_path, prompts_path)
+                        prompt_files.append(rel_path)
+        except Exception:
+            prompt_files = []
+
+        return {"required": {
+            "prompt_file": (prompt_files,),
+            "index": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
+            }
+        }
+
+    RETURN_TYPES = ("ZIPPED_PROMPT",)
+    OUTPUT_IS_LIST = (True,)
+
+    FUNCTION = "doit"
+
+    CATEGORY = "InspirePack/prompt"
+
+    def doit(self, prompt_file, index):
+        prompt_path = os.path.join(prompts_path, prompt_file)
+
+        prompts = []
+        try:
+            with open(prompt_path, "r", encoding="utf-8") as file:
+                prompt_data = file.read()
+                prompt_list = re.split(r'\n\s*-+\s*\n', prompt_data)
+                try:
+                    prompt = prompt_list[index]
+                except Exception:
+                    prompt = prompt_list[-1]
+
+                pattern = r"positive:(.*?)(?:\n*|$)negative:(.*)"
+                matches = re.search(pattern, prompt, re.DOTALL)
+
+                if matches:
+                    positive_text = matches.group(1).strip()
+                    negative_text = matches.group(2).strip()
+                    result_tuple = (positive_text, negative_text, prompt_file)
+                    prompts.append(result_tuple)
+                else:
+                    print(f"[WARN] LoadPromptsFromFile: invalid prompt format in '{prompt_file}'")
+        except Exception as e:
+            print(f"[ERROR] LoadPromptsFromFile: an error occurred while processing '{prompt_file}': {str(e)}")
+
+        return (prompts, )
+
+
 class UnzipPrompt:
     @classmethod
     def INPUT_TYPES(s):
@@ -537,6 +594,7 @@ class CLIPTextEncodeWithWeight:
 NODE_CLASS_MAPPINGS = {
     "LoadPromptsFromDir //Inspire": LoadPromptsFromDir,
     "LoadPromptsFromFile //Inspire": LoadPromptsFromFile,
+    "LoadSinglePromptFromFile //Inspire": LoadSinglePromptFromFile,
     "UnzipPrompt //Inspire": UnzipPrompt,
     "ZipPrompt //Inspire": ZipPrompt,
     "PromptExtractor //Inspire": PromptExtractor,
@@ -551,6 +609,7 @@ NODE_CLASS_MAPPINGS = {
 NODE_DISPLAY_NAME_MAPPINGS = {
     "LoadPromptsFromDir //Inspire": "Load Prompts From Dir (Inspire)",
     "LoadPromptsFromFile //Inspire": "Load Prompts From File (Inspire)",
+    "LoadSinglePromptFromFile //Inspire": "Load Single Prompt From File (Inspire)",
     "UnzipPrompt //Inspire": "Unzip Prompt (Inspire)",
     "ZipPrompt //Inspire": "Zip Prompt (Inspire)",
     "PromptExtractor //Inspire": "Prompt Extractor (Inspire)",


### PR DESCRIPTION
The new node allows the user to load a specific prompt from the file instead of processing the entire list.

Use Case: When you prefer to advance your prompts manually instead of iterating through the entire list.

Note: If the index is larger than the list, the last item in the list will be returned.