### PR TITLE
Merge identical categories

### DIFF
--- a/inspire/list_nodes.py
+++ b/inspire/list_nodes.py
@@ -15,7 +15,7 @@ class FloatRange:
 
     FUNCTION = "doit"
 
-    CATEGORY = "InspirePack/util"
+    CATEGORY = "InspirePack/Util"
 
     def doit(self, start, stop, step, limit, ensure_end):
         if start >= stop or step == 0:

--- a/inspire/prompt_support.py
+++ b/inspire/prompt_support.py
@@ -55,7 +55,7 @@ class LoadPromptsFromDir:
 
     FUNCTION = "doit"
 
-    CATEGORY = "InspirePack/prompt"
+    CATEGORY = "InspirePack/Prompt"
 
     def doit(self, prompt_dir):
         global prompts_path
@@ -110,7 +110,7 @@ class LoadPromptsFromFile:
 
     FUNCTION = "doit"
 
-    CATEGORY = "InspirePack/prompt"
+    CATEGORY = "InspirePack/Prompt"
 
     def doit(self, prompt_file):
         prompt_path = os.path.join(prompts_path, prompt_file)
@@ -165,7 +165,7 @@ class LoadSinglePromptFromFile:
 
     FUNCTION = "doit"
 
-    CATEGORY = "InspirePack/prompt"
+    CATEGORY = "InspirePack/Prompt"
 
     def doit(self, prompt_file, index):
         prompt_path = os.path.join(prompts_path, prompt_file)
@@ -206,7 +206,7 @@ class UnzipPrompt:
 
     FUNCTION = "doit"
 
-    CATEGORY = "InspirePack/prompt"
+    CATEGORY = "InspirePack/Prompt"
 
     def doit(self, zipped_prompt):
         return zipped_prompt
@@ -228,7 +228,7 @@ class ZipPrompt:
 
     FUNCTION = "doit"
 
-    CATEGORY = "InspirePack/prompt"
+    CATEGORY = "InspirePack/Prompt"
 
     def doit(self, positive, negative, name_opt=""):
         return ((positive, negative, name_opt), )
@@ -252,7 +252,7 @@ class PromptExtractor:
                 "hidden": {"unique_id": "UNIQUE_ID"},
                 }
 
-    CATEGORY = "InspirePack/prompt"
+    CATEGORY = "InspirePack/Prompt"
 
     RETURN_TYPES = ("STRING", "STRING")
     RETURN_NAMES = ("positive", "negative")


### PR DESCRIPTION
Several categories had been split apart based on the capitalization of the name, with the names otherwise being identical. (For example, there was a "InspirePack/prompt" category and a "InspirePack/Prompt" category.) This cluttered up the submenu with junk, so I merged those categories together by fixing the capitalization.