### PR TITLE
Minor fix to prompt_seed_update

### DIFF
--- a/inspire/inspire_server.py
+++ b/inspire/inspire_server.py
@@ -104,7 +104,7 @@ def prompt_seed_update(json_data):
     try:
         widget_idx_map = json_data['extra_data']['extra_pnginfo']['workflow']['widget_idx_map']
     except Exception:
-        return None
+        return False, None
 
     value = None
     mode = None


### PR DESCRIPTION
If the json_data isn't available, return a value that can still be handled downstream.

Before, when it returns None, the onprompt handler chokes when unpacking the return value.