### PR TITLE
Add ability to use Load Image Batch from Dir node, to load the last / latest image in a directory

### DIFF
--- a/inspire/image_util.py
+++ b/inspire/image_util.py
@@ -18,7 +18,7 @@ class LoadImagesFromDirBatch:
             },
             "optional": {
                 "image_load_cap": ("INT", {"default": 0, "min": 0, "step": 1}),
-                "start_index": ("INT", {"default": 0, "min": 0, "step": 1}),
+                "start_index": ("INT", {"default": 0, "min": -1, "step": 1}),
                 "load_always": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled"}),
             }
         }


### PR DESCRIPTION
Hi, I adjusted the minimum value on the Load Image Batch From Dir node from 0 to -1, this way you can use it to grab the last image from a directory.

I'm using it to feed the latest generated output image back to the front of my network as a latent image.