### PR TITLE
Add xinsir black pixel support to inpainting controlnet preprocessor

### DIFF
--- a/inspire/segs_support.py
+++ b/inspire/segs_support.py
@@ -110,6 +110,9 @@ class Color_Preprocessor_wrapper:
 
 
 class InpaintPreprocessor_wrapper:
+    def __init__(self, black_pixel_for_xinsir_cn):
+        self.black_pixel_for_xinsir_cn = black_pixel_for_xinsir_cn
+    
     def apply(self, image, mask=None):
         if 'InpaintPreprocessor' not in nodes.NODE_CLASS_MAPPINGS:
             utils.try_install_custom_node('https://github.com/Fannovel16/comfyui_controlnet_aux',
@@ -120,7 +123,7 @@ class InpaintPreprocessor_wrapper:
         if mask is None:
             mask = torch.ones((image.shape[1], image.shape[2]), dtype=torch.float32, device="cpu").unsqueeze(0)
 
-        return obj.preprocess(image, mask)[0]
+        return obj.preprocess(image, mask, self.black_pixel_for_xinsir_cn)[0]
 
 
 class TilePreprocessor_wrapper:
@@ -547,14 +550,16 @@ class Color_Preprocessor_Provider_for_SEGS:
 class InpaintPreprocessor_Provider_for_SEGS:
     @classmethod
     def INPUT_TYPES(s):
-        return {"required": {}}
+        return {"required": {
+            "black_pixel_for_xinsir_cn": ("BOOLEAN", {"default": False, "label_on": "enable", "label_off": "disable"}),
+        }}
     RETURN_TYPES = ("SEGS_PREPROCESSOR",)
     FUNCTION = "doit"
 
     CATEGORY = "InspirePack/SEGS/ControlNet"
 
-    def doit(self):
-        obj = InpaintPreprocessor_wrapper()
+    def doit(self, black_pixel_for_xinsir_cn):
+        obj = InpaintPreprocessor_wrapper(black_pixel_for_xinsir_cn)
         return (obj, )
 
 


### PR DESCRIPTION
A port for a xinsir inpainting color fix feature from [comfyui_controlnet_aux](https://github.com/Fannovel16/comfyui_controlnet_aux) to Inspire Pack Inpaint Preprocessor Provider (SEGS).

![image](https://github.com/user-attachments/assets/e582d119-8df3-4cc0-a92b-71f62a2af365)

