### PR TITLE
support named colors via webcolors module

### DIFF
--- a/inspire/regional_nodes.py
+++ b/inspire/regional_nodes.py
@@ -4,6 +4,7 @@ import comfy
 import nodes
 import torch
 import re
+import webcolors
 
 from . import prompt_support
 from .libs import utils, common
@@ -81,8 +82,9 @@ class RegionalPromptSimple:
 
 def color_to_mask(color_mask, mask_color):
     try:
-        if mask_color.startswith("#"):
-            selected = int(mask_color[1:], 16)
+        if mask_color.startswith("#") or mask_color.isalpha():
+            hex = mask_color[1:] if mask_color.startswith("#") else webcolors.name_to_hex(mask_color)[1:]
+            selected = int(hex, 16)
         else:
             selected = int(mask_color, 10)
     except Exception:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 matplotlib
 cachetools
 numpy<2
+webcolors
+


### PR DESCRIPTION
I don't want to remember hex values. With this you can also enter colors names like "olive" instead of #808000.

https://www.w3.org/TR/SVG11/types.html#ColorKeywords
https://webcolors.readthedocs.io/en/latest/colors.html
https://webcolors.readthedocs.io/en/latest/contents.html#conversions-from-color-names-to-other-formats

color picker in comfyui would also be nice.
edit: oh, I just remembered this can be done with browser devtools