### PR TITLE
Fix type of "model" input of SeedExplorer node

### DIFF
--- a/inspire/prompt_support.py
+++ b/inspire/prompt_support.py
@@ -674,7 +674,7 @@ class SeedExplorer:
             "optional":
                 {
                     "variation_method": (["linear", "slerp"],),
-                    "model": ("model",),
+                    "model": ("MODEL",),
                 }
         }
 


### PR DESCRIPTION
The type of this input was "model" in lowercase, which is unusual and does not work well with ComfyUI node search (see screenshots if it's not clear).
![2024-11-04_21-11](https://github.com/user-attachments/assets/7a5efb55-95dd-462b-be52-310ea706dbd7)
![2024-11-04_21-13](https://github.com/user-attachments/assets/ecb96fc6-1271-4234-84e2-4312836de562)
