### PR TITLE
patch to fix error when workflow is called via API

### DIFF
--- a/inspire/inspire_server.py
+++ b/inspire/inspire_server.py
@@ -332,7 +332,7 @@ def populate_wildcards(json_data):
 
         if 'extra_data' in json_data and 'extra_pnginfo' in json_data['extra_data']:
             extra_pnginfo = json_data['extra_data']['extra_pnginfo']
-            if 'workflow' in extra_pnginfo and 'nodes' in extra_pnginfo['workflow']:
+            if 'workflow' in extra_pnginfo and extra_pnginfo['workflow'] is not None and 'nodes' in extra_pnginfo['workflow']:
                 for node in extra_pnginfo['workflow']['nodes']:
                     key = str(node['id'])
                     if key in updated_widget_values:


### PR DESCRIPTION
When workflow is called via API it bugs out as the value of extra_pnginfo is {'workflow': None} and it gives the error 'NoneType' object is not subscriptable.