### PR TITLE
Return an empty list from RetrieveBackendData rather than throwing a runtime error

### DIFF
--- a/inspire/backend_support.py
+++ b/inspire/backend_support.py
@@ -189,7 +189,7 @@ class RetrieveBackendData:
 
         if v is None:
             logging.warning(f"[RetrieveBackendData] '{key}' is unregistered key.")
-            return (None,)
+            return ([None],)
 
         is_list, data = v[1]
 


### PR DESCRIPTION
Return an empty list from RetrieveBackendData rather than throwing a runtime error.

The absence of a key in the cache should not lead to the workflow stopping, since the tags are not always initialized when the workflow is started.

The introduced fix allows you to return an empty list from a function (node) and not stop the workflow with a fatal error "TypeError: 'NoneType' object is not iterable".

Without this fix, it is impossible to use the main feature of this node - namely, to start the workflow without necessarily filling the keyword with data, and therefore to use nodes correctly.

An example of a scenario (workflow), when an empty value is expected to be returned instead of a fatal error:
![image](https://github.com/user-attachments/assets/14b324eb-ca40-4bfb-b132-f454e628c0cd)

Also, such functionality is necessary for the implementation of various scenarios such as reusing a regenerated image during Inpaint.