### PR TITLE
MakeBasicPipe updated to have 2 more inputs and save populated text by default

### DIFF
--- a/inspire/inspire_server.py
+++ b/inspire/inspire_server.py
@@ -312,41 +312,6 @@ def populate_wildcards(json_data):
                 if inputs['mode'] == 'reproduce':
                     server.PromptServer.instance.send_sync("inspire-node-feedback", {"node_id": k, "widget_name": "mode", "type": "text", "value": 'populate'})
 
-            elif 'class_type' in v and v['class_type'] == 'MakeBasicPipe //Inspire':
-                inputs = v['inputs']
-                if inputs['wildcard_mode'] == 'populate' and (isinstance(inputs['positive_populated_text'], str) or isinstance(inputs['negative_populated_text'], str)):
-                    if isinstance(inputs['seed'], list):
-                        try:
-                            input_node = prompt[inputs['seed'][0]]
-                            if input_node['class_type'] == 'ImpactInt':
-                                input_seed = int(input_node['inputs']['value'])
-                                if not isinstance(input_seed, int):
-                                    continue
-                            if input_node['class_type'] == 'Seed (rgthree)':
-                                input_seed = int(input_node['inputs']['seed'])
-                                if not isinstance(input_seed, int):
-                                    continue
-                            else:
-                                logging.warning("[Inspire Pack] Only `ImpactInt`, `Seed (rgthree)` and `Primitive` Node are allowed as the seed for '{v['class_type']}'. It will be ignored. ")
-                                continue
-                        except:
-                            continue
-                    else:
-                        input_seed = int(inputs['seed'])
-
-                    if isinstance(inputs['positive_populated_text'], str):
-                        inputs['positive_populated_text'] = wildcard_process(text=inputs['positive_wildcard_text'], seed=input_seed)
-                        server.PromptServer.instance.send_sync("inspire-node-feedback", {"node_id": k, "widget_name": "positive_populated_text", "type": "text", "data": inputs['positive_populated_text']})
-
-                    if isinstance(inputs['negative_populated_text'], str):
-                        inputs['negative_populated_text'] = wildcard_process(text=inputs['negative_wildcard_text'], seed=input_seed)
-                        server.PromptServer.instance.send_sync("inspire-node-feedback", {"node_id": k, "widget_name": "negative_populated_text", "type": "text", "data": inputs['negative_populated_text']})
-
-                    inputs['wildcard_mode'] = 'reproduce'
-                    mbp_updated_widget_values[k] = inputs['positive_populated_text'], inputs['negative_populated_text']
-
-                if inputs['wildcard_mode'] == 'reproduce':
-                    server.PromptServer.instance.send_sync("inspire-node-feedback", {"node_id": k, "widget_name": "wildcard_mode", "type": "text", "value": 'populate'})
 
         if 'extra_data' in json_data and 'extra_pnginfo' in json_data['extra_data']:
             extra_pnginfo = json_data['extra_data']['extra_pnginfo']

--- a/inspire/prompt_support.py
+++ b/inspire/prompt_support.py
@@ -649,60 +649,100 @@ class MakeBasicPipe:
         return {"required": {
                         "ckpt_name": (folder_paths.get_filename_list("checkpoints"), ),
                         "ckpt_key_opt": ("STRING", {"multiline": False, "placeholder": "If empty, use 'ckpt_name' as the key." }),
-
                         "positive_wildcard_text": ("STRING", {"multiline": True, "dynamicPrompts": False, 'placeholder': 'Positive Prompt (User Input)'}),
                         "negative_wildcard_text": ("STRING", {"multiline": True, "dynamicPrompts": False, 'placeholder': 'Negative Prompt (User Input)'}),
-
                         "Add selection to": ("BOOLEAN", {"default": True, "label_on": "Positive", "label_off": "Negative"}),
                         "Select to add LoRA": (["Select the LoRA to add to the text"] + folder_paths.get_filename_list("loras"),),
                         "Select to add Wildcard": (["Select the Wildcard to add to the text"],),
-                        "wildcard_mode": (["populate", "fixed", "reproduce"], {"default": "populate", "tooltip":
-                            "populate: Before running the workflow, it overwrites the existing value of 'populated_text' with the prompt processed from 'wildcard_text'. In this mode, 'populated_text' cannot be edited.\n"
-                            "fixed: Ignores wildcard_text and keeps 'populated_text' as is. You can edit 'populated_text' in this mode.\n"
-                            "reproduce: This mode operates as 'fixed' mode only once for reproduction, and then it switches to 'populate' mode."
-                                                                               }),
-
+                        "wildcard_mode": (["populate", "fixed"], {"default": "populate", "tooltip":
+                            "populate: Processes wildcards and linked text. On the next run, this text will be used.\n"
+                            "fixed: Ignores wildcard/linked text and uses the text in 'populated_text' as is."}),
                         "positive_populated_text": ("STRING", {"multiline": True, "dynamicPrompts": False, 'placeholder': 'Populated Positive Prompt (Will be generated automatically)'}),
                         "negative_populated_text": ("STRING", {"multiline": True, "dynamicPrompts": False, 'placeholder': 'Populated Negative Prompt (Will be generated automatically)'}),
-
                         "token_normalization": (["none", "mean", "length", "length+mean"],),
                         "weight_interpretation": (["comfy", "A1111", "compel", "comfy++", "down_weight"], {'default': 'comfy++'}),
-
                         "stop_at_clip_layer": ("INT", {"default": -2, "min": -24, "max": -1, "step": 1}),
                         "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
                     },
                 "optional": {
-                        "vae_opt": ("VAE",)
+                        "vae_opt": ("VAE",),
+                        "pos_opt": ("STRING", {"forceInput": True}),
+                        "neg_opt": ("STRING", {"forceInput": True}),
                     },
+                "hidden": {
+                    "unique_id": "UNIQUE_ID", "extra_pnginfo": "EXTRA_PNGINFO"
                 }
-
+            }
+            
     CATEGORY = "InspirePack/Prompt"
-
     RETURN_TYPES = ("BASIC_PIPE", "STRING")
     RETURN_NAMES = ("basic_pipe", "cache_key")
     FUNCTION = "doit"
 
-    def doit(self, **kwargs):
-        pos_populated = kwargs['positive_populated_text']
-        neg_populated = kwargs['negative_populated_text']
+    # --- THE NEW DOIT METHOD ---
+    def doit(self, unique_id, extra_pnginfo, **kwargs):
+        # Get all other values from kwargs
+        wildcard_mode = kwargs['wildcard_mode']
+        positive_wildcard_text = kwargs['positive_wildcard_text']
+        negative_wildcard_text = kwargs['negative_wildcard_text']
+        seed = kwargs['seed']
+        pos_opt_fresh = kwargs.get('pos_opt', '')
+        neg_opt_fresh = kwargs.get('neg_opt', '')
 
+        if wildcard_mode == 'populate':
+            # 1. Calculate the final definitive prompt
+            pos_parts = [p.strip() for p in [pos_opt_fresh, positive_wildcard_text] if p and p.strip()]
+            pos_combined_source = ", ".join(pos_parts)
+            neg_parts = [p.strip() for p in [neg_opt_fresh, negative_wildcard_text] if p and p.strip()]
+            neg_combined_source = ", ".join(neg_parts)
+
+            final_positive_prompt = nodes.NODE_CLASS_MAPPINGS['ImpactWildcardProcessor'].process(text=pos_combined_source, seed=seed)
+            final_negative_prompt = nodes.NODE_CLASS_MAPPINGS['ImpactWildcardProcessor'].process(text=neg_combined_source, seed=seed)
+            
+            # --- 2. BACKEND: Modify the PNG info for correct image saving ---
+            if extra_pnginfo and 'workflow' in extra_pnginfo:
+                workflow = extra_pnginfo['workflow']
+                node = next((n for n in workflow['nodes'] if n['id'] == int(unique_id)), None)
+                if node:
+                    all_widgets = list(self.INPUT_TYPES()['required'].keys())
+                    pos_widget_index = all_widgets.index('positive_populated_text')
+                    neg_widget_index = all_widgets.index('negative_populated_text')
+                    mode_widget_index = all_widgets.index('wildcard_mode')
+                    
+                    # Overwrite values to be saved in the PNG with the locked-in state
+                    node['widgets_values'][pos_widget_index] = final_positive_prompt
+                    node['widgets_values'][neg_widget_index] = final_negative_prompt
+                    node['widgets_values'][mode_widget_index] = "fixed"
+
+            # --- 3. FRONTEND: Send live updates to the browser UI ---
+            server_instance = PromptServer.instance
+            server_instance.send_sync("inspire-node-feedback", {"node_id": unique_id, "widget_name": "positive_populated_text", "data": final_positive_prompt})
+            server_instance.send_sync("inspire-node-feedback", {"node_id": unique_id, "widget_name": "negative_populated_text", "data": final_negative_prompt})
+            
+            # THIS IS THE NEW LOGIC: Tell the UI to revert back to 'populate' for convenience
+            server_instance.send_sync("inspire-node-feedback", {"node_id": unique_id, "widget_name": "wildcard_mode", "value": "populate"})
+
+        else: # wildcard_mode == 'fixed'
+            # --- REPRODUCE PATH ---
+            # Use the text that's already in the populated widgets
+            final_positive_prompt = kwargs['positive_populated_text']
+            final_negative_prompt = kwargs['negative_populated_text']
+
+
+        # 4. Use the final prompts for this run's image generation
         clip_encoder = BNK_EncoderWrapper(kwargs['token_normalization'], kwargs['weight_interpretation'])
-
         if 'ImpactWildcardEncode' not in nodes.NODE_CLASS_MAPPINGS:
-            utils.try_install_custom_node('https://github.com/ltdrdata/ComfyUI-Impact-Pack',
-                                          "To use 'Make Basic Pipe (Inspire)' node, 'Impact Pack' extension is required.")
-            raise Exception("[ERROR] To use 'Make Basic Pipe (Inspire)', you need to install 'Impact Pack'")
+            raise Exception("[ERROR] 'Impact Pack' is required.")
 
         model, clip, vae, key = CheckpointLoaderSimpleShared().doit(ckpt_name=kwargs['ckpt_name'], key_opt=kwargs['ckpt_key_opt'])
         clip = nodes.CLIPSetLastLayer().set_last_layer(clip, kwargs['stop_at_clip_layer'])[0]
-        model, clip, positive = nodes.NODE_CLASS_MAPPINGS['ImpactWildcardEncode'].process_with_loras(wildcard_opt=pos_populated, model=model, clip=clip, clip_encoder=clip_encoder)
-        model, clip, negative = nodes.NODE_CLASS_MAPPINGS['ImpactWildcardEncode'].process_with_loras(wildcard_opt=neg_populated, model=model, clip=clip, clip_encoder=clip_encoder)
+        model, clip, positive = nodes.NODE_CLASS_MAPPINGS['ImpactWildcardEncode'].process_with_loras(wildcard_opt=final_positive_prompt, model=model, clip=clip, clip_encoder=clip_encoder)
+        model, clip, negative = nodes.NODE_CLASS_MAPPINGS['ImpactWildcardEncode'].process_with_loras(wildcard_opt=final_negative_prompt, model=model, clip=clip, clip_encoder=clip_encoder)
 
         if 'vae_opt' in kwargs:
             vae = kwargs['vae_opt']
 
         basic_pipe = model, clip, vae, positive, negative
-
         return (basic_pipe, key)
 
 

--- a/js/prompt.js
+++ b/js/prompt.js
@@ -25,11 +25,46 @@ async function get_prompt_builder_items(category) {
 		return data.presets;
 	}
 }
+function setupInspireNodeFeedback(api) {
+	if (!api) {
+		console.error("Inspire Pack: Could not find app.api. Node feedback will not work.");
+		return;
+	}
 
+	api.addEventListener("inspire-node-feedback", ({ detail }) => {
+		const node = app.graph.getNodeById(detail.node_id);
+		if (!node) return;
+
+		const widget = node.widgets.find(w => w.name === detail.widget_name);
+		if (!widget) return;
+
+		const newValue = detail.data !== undefined ? detail.data : detail.value;
+
+		// 1. Update the live value for the UI.
+		widget.value = newValue;
+
+		// 2. Update the node's underlying serialization array.
+		const widgetIndex = node.widgets.indexOf(widget);
+		if (node.widgets_values && widgetIndex > -1) {
+			node.widgets_values[widgetIndex] = newValue;
+		}
+
+		// 3. Mark the canvas as dirty to ensure saves are correct.
+		app.graph.setDirtyCanvas(true, true);
+
+		// Special case: if we updated the mode combo, manually trigger its callback.
+		if (widget.name === "wildcard_mode" && widget.callback) {
+			widget.callback(newValue);
+		}
+	});
+}
 
 app.registerExtension({
 	name: "Comfy.Inspire.Prompts",
-
+	async setup(app) { // The signature only has one argument: 'app'
+		// We get the api from the app object and pass it to our helper
+		setupInspireNodeFeedback(app.api);
+	},
 	nodeCreated(node, app) {
 		if(node.comfyClass == "WildcardEncode //Inspire") {
 			const wildcard_text_widget_index = node.widgets.findIndex((w) => w.name == 'wildcard_text');
@@ -112,98 +147,85 @@ app.registerExtension({
 					 }
 			});
 		}
-		else if(node.comfyClass == "MakeBasicPipe //Inspire") {
+		else if (node.comfyClass === "MakeBasicPipe //Inspire") {
+			// Find widgets by name for robustness
 			const pos_wildcard_text_widget = node.widgets.find((w) => w.name == 'positive_wildcard_text');
-			const pos_populated_text_widget = node.widgets.find((w) => w.name == 'positive_populated_text');
 			const neg_wildcard_text_widget = node.widgets.find((w) => w.name == 'negative_wildcard_text');
+			const pos_populated_text_widget = node.widgets.find((w) => w.name == 'positive_populated_text');
 			const neg_populated_text_widget = node.widgets.find((w) => w.name == 'negative_populated_text');
-
 			const mode_widget = node.widgets.find((w) => w.name == 'wildcard_mode');
 			const direction_widget = node.widgets.find((w) => w.name == 'Add selection to');
+			const lora_widget = node.widgets.find((w) => w.name == 'Select to add LoRA');
+			const wildcard_widget = node.widgets.find((w) => w.name == 'Select to add Wildcard');
 
-			// lora selector, wildcard selector
-			let combo_id = 5;
+			// --- Your original LoRA Selector Logic, Preserved ---
+			lora_widget.callback = (value, canvas, node, pos, e) => {
+				const lora_name = lora_widget._lora_value;
+				if (!lora_name) return;
+				const final_lora_name = lora_name.endsWith('.safetensors') ? lora_name.slice(0, -12) : lora_name;
+				const target_widget = direction_widget.value ? pos_wildcard_text_widget : neg_wildcard_text_widget;
 
-            node.widgets[combo_id].callback = (value, canvas, node, pos, e) => {
-                let lora_name = node._lora_value;
-                if (lora_name.endsWith('.safetensors')) {
-                    lora_name = lora_name.slice(0, -12);
-                }
-
-                if(direction_widget.value) {
-                    pos_wildcard_text_widget.value += `<lora:${lora_name}>`;
-                }
-                else {
-                    neg_wildcard_text_widget.value += `<lora:${lora_name}>`;
-                }
-            }
-			Object.defineProperty(node.widgets[combo_id], "value", {
-				set: (value) => {
-                        if (value !== "Select the LoRA to add to the text")
-                            node._lora_value = value;
-					},
-				get: () => { return "Select the LoRA to add to the text"; }
+				// Add a comma if needed
+				if (target_widget.value.trim() !== '' && !target_widget.value.trim().endsWith(',')) {
+					target_widget.value += ', ';
+				}
+				target_widget.value += `<lora:${final_lora_name}:1.0>`;
+				app.graph.setDirtyCanvas(true, true);
+			}
+			Object.defineProperty(lora_widget, "value", {
+				set: (value) => { lora_widget._lora_value = (value !== "Select the LoRA to add to the text") ? value : null; },
+				get: () => "Select the LoRA to add to the text"
 			});
 
-            node.widgets[combo_id+1].callback = (value, canvas, node, pos, e) => {
-                let w = null;
-                if(direction_widget.value) {
-                    w = pos_wildcard_text_widget;
-                }
-                else {
-                    w = neg_wildcard_text_widget;
-                }
+			wildcard_widget.callback = (value, canvas, node, pos, e) => {
+				const wildcard_name = wildcard_widget._wildcard_value;
+				if (!wildcard_name) return;
+				const target_widget = direction_widget.value ? pos_wildcard_text_widget : neg_wildcard_text_widget;
 
-                if(w.value != '')
-                    w.value += ', '
-
-                w.value += node._wildcard_value;
-            }
-
-			Object.defineProperty(node.widgets[combo_id+1], "value", {
-				set: (value) => {
-                        if (value !== "Select the Wildcard to add to the text")
-                            node._wildcard_value = value;
-					},
-				get: () => { return "Select the Wildcard to add to the text"; }
+				// Add a comma if needed
+				if (target_widget.value.trim() !== '' && !target_widget.value.trim().endsWith(',')) {
+					target_widget.value += ', ';
+				}
+				// Add the wildcard with standard syntax
+				target_widget.value += wildcard_name;
+				app.graph.setDirtyCanvas(true, true);
+			}
+			Object.defineProperty(wildcard_widget, "value", {
+				set: (value) => { wildcard_widget._wildcard_value = (value !== "Select the Wildcard to add to the text") ? value : null; },
+				get: () => "Select the Wildcard to add to the text"
 			});
 
-			Object.defineProperty(node.widgets[combo_id+1].options, "values", {
-				set: (x) => {},
+			Object.defineProperty(wildcard_widget.options, "values", {
+				set: (x) => { },
 				get: () => {
-					return get_wildcards_list();
+					// Check if the dependency function exists before calling it
+					if (typeof get_wildcards_list === 'function') {
+						return ["Select the Wildcard to add to the text"].concat(get_wildcards_list());
+					}
+					// Fallback if the dependency is not loaded
+					return ["Select the Wildcard to add to the text", "---(Wildcard dependency not found)---"];
 				}
 			});
 
-			// Preventing validation errors from occurring in any situation.
-			node.widgets[combo_id].serializeValue = () => { return "Select the LoRA to add to the text"; }
-			node.widgets[combo_id+1].serializeValue = () => { return "Select the Wildcard to add to the text"; }
+			// Serialization prevention for combo boxes
+			lora_widget.serializeValue = () => "Select the LoRA to add to the text";
+			wildcard_widget.serializeValue = () => "Select the Wildcard to add to the text";
 
-			// wildcard populating
-			pos_populated_text_widget.inputEl.disabled = true;
-			neg_populated_text_widget.inputEl.disabled = true;
+			// Mode control logic
+			const original_mode_callback = mode_widget.callback;
+			mode_widget.callback = function (value) {
+				const is_fixed = (value === 'fixed');
+				pos_populated_text_widget.inputEl.readOnly = !is_fixed;
+				neg_populated_text_widget.inputEl.readOnly = !is_fixed;
+				pos_populated_text_widget.inputEl.style.opacity = is_fixed ? 1.0 : 0.6;
+				neg_populated_text_widget.inputEl.style.opacity = is_fixed ? 1.0 : 0.6;
+				original_mode_callback?.apply(this, arguments);
+			}
 
-			// mode combo
-			Object.defineProperty(mode_widget, "value", {
-				set: (value) => {
-						if(value == true)
-							node._mode_value = "populate";
-						else if(value == false)
-							node._mode_value = "fixed";
-						else
-							node._mode_value = value; // combo value
-
-						pos_populated_text_widget.inputEl.disabled = node._mode_value == 'populate';
-						neg_populated_text_widget.inputEl.disabled = node._mode_value == 'populate';
-					},
-				get: () => {
-						if(node._mode_value != undefined)
-							return node._mode_value;
-						else
-							return 'populate';
-					 }
-			});
+			// Set initial UI state on load
+			setTimeout(() => { if (mode_widget.callback) mode_widget.callback(mode_widget.value); }, 200);
 		}
+
 		else if(node.comfyClass == "PromptBuilder //Inspire") {
 			const preset_widget = node.widgets[node.widgets.findIndex(obj => obj.name === 'preset')];
 			const category_widget = node.widgets[node.widgets.findIndex(obj => obj.name === 'category')];


### PR DESCRIPTION
This update save the populated text to the workflow file by default, and adds two optional linked inputs `pos_opt` and `neg_opt`

Implementation Details:
- A function to resolve linked inputs.
- A client-side listener (`inspire-node-feedback`) updates the UI widgets with the final text, making the changes persistent.

User case for the 2 inputs:
![image](https://github.com/user-attachments/assets/63b281d3-65b9-4b5e-a511-603d6184b765)
