### PR TITLE
Refactor IPAdapter Model Helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ This repository offers various extension nodes for ComfyUI. Nodes here have diff
   * `Conditioning Stretch (Inspire)`: When upscaling an image, it helps to expand the conditioning area by specifying the original resolution and the new resolution to be applied. Taken from [ComfyUI_Dave_CustomNode](https://github.com/Davemane42/ComfyUI_Dave_CustomNode)
 
 ### Models - Nodes for models
-  * `IPAdapter Model Helper (Inspire)`: This provides presets that allow for easy loading of the IPAdapter related models. However, it is essential for the model's name to be accurate.
+  * `IPAdapter Model Helper (Inspire)`: This provides dropdowns for easy selection of IPAdapter, CLIP vision, and LoRA models. Automatically scans your model folders.
     * You can download the appropriate model through ComfyUI-Manager.
+    * Supports `extra_model_paths.yaml` - You can specify custom model locations using the `ipadapter`, `clip_vision`, and `loras` keys.
 
 ### List - Nodes for List processing
   * `Float Range (Inspire)`: Create a float list that increases the value by `step` from `start` to `stop`. A list as large as the maximum limit is created, and when `ensure_end` is enabled, the last value of the list becomes the stop value.

--- a/extra_model_paths.yaml.example
+++ b/extra_model_paths.yaml.example
@@ -1,0 +1,25 @@
+# ComfyUI-Inspire-Pack Extra Model Paths Configuration Example
+# Copy this file to your ComfyUI root directory as 'extra_model_paths.yaml'
+# and uncomment/modify the paths below to match your setup.
+
+# Basic configuration example
+# my_config:
+#   base_path: "/path/to/your/models/"
+#   ipadapter: "ipadapter/"
+#   checkpoints: "checkpoints/"
+#   loras: "loras/"
+#   clip_vision: "clip_vision/"
+
+# Windows example with different drive
+# windows_config:
+#   base_path: "E:/AI_Models/"
+#   ipadapter: "IPAdapter/"
+#   checkpoints: "checkpoints/"
+
+# Multiple paths example
+# multi_path_config:
+#   ipadapter: |
+#     /first/ipadapter/path/
+#     /second/ipadapter/path/
+
+# After configuring, restart ComfyUI to load models from your custom locations.

--- a/inspire/model_nodes.py
+++ b/inspire/model_nodes.py
@@ -8,39 +8,6 @@ from comfy import sdxl_clip
 import logging
 
 
-model_preset = {
-    # base
-    "SD1.5":                ("ip-adapter_sd15",                 "CLIP-ViT-H-14-laion2B-s32B-b79K", None, False),
-    "SD1.5 Light v11":      ("ip-adapter_sd15_light_v11",       "CLIP-ViT-H-14-laion2B-s32B-b79K", None, False),
-    "SD1.5 Light":          ("ip-adapter_sd15_light",           "CLIP-ViT-H-14-laion2B-s32B-b79K", None, False),
-    "SD1.5 Plus":           ("ip-adapter-plus_sd15",            "CLIP-ViT-H-14-laion2B-s32B-b79K", None, False),
-    "SD1.5 Plus Face":      ("ip-adapter-plus-face_sd15",       "CLIP-ViT-H-14-laion2B-s32B-b79K", None, False),
-    "SD1.5 Full Face":      ("ip-adapter-full-face_sd15",       "CLIP-ViT-H-14-laion2B-s32B-b79K", None, False),
-    "SD1.5 ViT-G":          ("ip-adapter_sd15_vit-G",           "CLIP-ViT-bigG-14-laion2B-39B-b160k", None, False),
-    "SDXL":                 ("ip-adapter_sdxl",                 "CLIP-ViT-bigG-14-laion2B-39B-b160k", None, False),
-    "SDXL ViT-H":           ("ip-adapter_sdxl_vit-h",           "CLIP-ViT-H-14-laion2B-s32B-b79K", None, False),
-    "SDXL Plus ViT-H":      ("ip-adapter-plus_sdxl_vit-h",      "CLIP-ViT-H-14-laion2B-s32B-b79K", None, False),
-    "SDXL Plus Face ViT-H": ("ip-adapter-plus-face_sdxl_vit-h", "CLIP-ViT-H-14-laion2B-s32B-b79K", None, False),
-    "Kolors Plus":          ("Kolors-IP-Adapter-Plus",          "clip-vit-large-patch14-336", None, False),
-
-    # faceid
-    "SD1.5 FaceID":                ("ip-adapter-faceid_sd15",                 "CLIP-ViT-H-14-laion2B-s32B-b79K", "ip-adapter-faceid_sd15_lora", True),
-    "SD1.5 FaceID Plus v2":        ("ip-adapter-faceid-plusv2_sd15",          "CLIP-ViT-H-14-laion2B-s32B-b79K", "ip-adapter-faceid-plusv2_sd15_lora", True),
-    "SD1.5 FaceID Plus":           ("ip-adapter-faceid-plus_sd15",            "CLIP-ViT-H-14-laion2B-s32B-b79K", "ip-adapter-faceid-plus_sd15_lora", True),
-    "SD1.5 FaceID Portrait v11":   ("ip-adapter-faceid-portrait-v11_sd15",    "CLIP-ViT-H-14-laion2B-s32B-b79K", None, True),
-    "SD1.5 FaceID Portrait":       ("ip-adapter-faceid-portrait_sd15",        "CLIP-ViT-H-14-laion2B-s32B-b79K", None, True),
-    "SDXL FaceID":                 ("ip-adapter-faceid_sdxl",                 "CLIP-ViT-H-14-laion2B-s32B-b79K", "ip-adapter-faceid_sdxl_lora", True),
-    "SDXL FaceID Plus v2":         ("ip-adapter-faceid-plusv2_sdxl",          "CLIP-ViT-H-14-laion2B-s32B-b79K", "ip-adapter-faceid-plusv2_sdxl_lora", True),
-    "SDXL FaceID Portrait":        ("ip-adapter-faceid-portrait_sdxl",        "CLIP-ViT-H-14-laion2B-s32B-b79K", None, True),
-    "SDXL FaceID Portrait unnorm": ("ip-adapter-faceid-portrait_sdxl_unnorm", "CLIP-ViT-H-14-laion2B-s32B-b79K", None, True),
-    "Kolors FaceID Plus":          ("Kolors-IP-Adapter-FaceID-Plus",          "clip-vit-large-patch14-336", None, True),
-
-    # composition
-    "SD1.5 Plus Composition":      ("ip-adapter_sd15", "CLIP-ViT-H-14-laion2B-s32B-b79K", None, False),
-    "SDXL Plus Composition":       ("ip-adapter_sdxl", "CLIP-ViT-bigG-14-laion2B-39B-b160k", None, False),
-    }
-
-
 def lookup_model(model_dir, name):
     if name is None:
         return None, "N/A"
@@ -58,10 +25,46 @@ def lookup_model(model_dir, name):
 class IPAdapterModelHelper:
     @classmethod
     def INPUT_TYPES(s):
+        # Scan for IPAdapter model files in the ipadapter folders
+        ipadapter_options = []
+        try:
+            ipadapter_files = folder_paths.get_filename_list("ipadapter")
+            for filename in ipadapter_files:
+                # Remove extension to get the base name
+                base_name = os.path.splitext(filename)[0]
+                ipadapter_options.append(base_name)
+        except Exception as e:
+            logging.warning(f"[Inspire Pack] IPAdapterModelHelper: Failed to scan ipadapter folder: {e}")
+        
+        # Scan for CLIP vision model files in the clip_vision folders
+        clipvision_options = []
+        try:
+            clip_vision_files = folder_paths.get_filename_list("clip_vision")
+            for filename in clip_vision_files:
+                # Remove extension to get the base name
+                base_name = os.path.splitext(filename)[0]
+                clipvision_options.append(base_name)
+        except Exception as e:
+            logging.warning(f"[Inspire Pack] IPAdapterModelHelper: Failed to scan clip_vision folder: {e}")
+        
+        # Scan for LoRA model files in the loras folders
+        lora_options = ["None"]  # Add "None" as first option for no LoRA
+        try:
+            lora_files = folder_paths.get_filename_list("loras")
+            for filename in lora_files:
+                # Remove extension to get the base name
+                base_name = os.path.splitext(filename)[0]
+                lora_options.append(base_name)
+        except Exception as e:
+            logging.warning(f"[Inspire Pack] IPAdapterModelHelper: Failed to scan loras folder: {e}")
+        
         return {
             "required": {
                 "model": ("MODEL",),
-                "preset": (list(model_preset.keys()),),
+                "ipadapter_model": (ipadapter_options,),
+                "clip_vision_model": (clipvision_options,),
+                "lora_model": (lora_options,),
+                "is_insightface": ("BOOLEAN", {"default": False}),
                 "lora_strength_model": ("FLOAT", {"default": 1.0, "min": -20.0, "max": 20.0, "step": 0.01}),
                 "lora_strength_clip": ("FLOAT", {"default": 1.0, "min": -20.0, "max": 20.0, "step": 0.01}),
                 "insightface_provider": (["CPU", "CUDA", "ROCM"], ),
@@ -80,28 +83,16 @@ class IPAdapterModelHelper:
 
     CATEGORY = "InspirePack/models"
 
-    def doit(self, model, preset, lora_strength_model, lora_strength_clip, insightface_provider, clip=None, cache_mode="none", unique_id=None, insightface_model_name='buffalo_l'):
+    def doit(self, model, ipadapter_model, clip_vision_model, lora_model, is_insightface, lora_strength_model, lora_strength_clip, insightface_provider, clip=None, cache_mode="none", unique_id=None, insightface_model_name='buffalo_l'):
         if 'IPAdapter' not in nodes.NODE_CLASS_MAPPINGS:
             utils.try_install_custom_node('https://github.com/cubiq/ComfyUI_IPAdapter_plus',
                                           "To use 'IPAdapterModelHelper' node, 'ComfyUI IPAdapter Plus' extension is required.")
             raise Exception("[ERROR] To use IPAdapterModelHelper, you need to install 'ComfyUI IPAdapter Plus'")
 
-        is_sdxl_preset = 'SDXL' in preset
-        if clip is not None:
-            is_sdxl_model = isinstance(clip.tokenizer, sdxl_clip.SDXLTokenizer)
-        else:
-            is_sdxl_model = False
-
-        if is_sdxl_preset != is_sdxl_model:
-            server.PromptServer.instance.send_sync("inspire-node-output-label", {"node_id": unique_id, "output_idx": 1, "label": "IPADAPTER (fail)"})
-            server.PromptServer.instance.send_sync("inspire-node-output-label", {"node_id": unique_id, "output_idx": 2, "label": "CLIP_VISION (fail)"})
-            server.PromptServer.instance.send_sync("inspire-node-output-label", {"node_id": unique_id, "output_idx": 3, "label": "INSIGHTFACE (fail)"})
-            server.PromptServer.instance.send_sync("inspire-node-output-label", {"node_id": unique_id, "output_idx": 4, "label": "MODEL (fail)"})
-            server.PromptServer.instance.send_sync("inspire-node-output-label", {"node_id": unique_id, "output_idx": 5, "label": "CLIP (fail)"})
-            logging.error("[Inspire Pack] IPAdapterModelHelper: You cannot mix SDXL and SD1.5 in the checkpoint and IPAdapter.")
-            raise Exception("[ERROR] You cannot mix SDXL and SD1.5 in the checkpoint and IPAdapter.")
-
-        ipadapter, clipvision, lora, is_insightface = model_preset[preset]
+        # Use the selected models directly
+        ipadapter = ipadapter_model
+        clipvision = clip_vision_model
+        lora = None if lora_model == "None" else lora_model
 
         ipadapter, ok1 = lookup_model("ipadapter", ipadapter)
         clipvision, ok2 = lookup_model("clip_vision", clipvision)

--- a/inspire/prompt_support.py
+++ b/inspire/prompt_support.py
@@ -23,6 +23,18 @@ import logging
 model_path = folder_paths.models_dir
 utils.add_folder_path_and_extensions("inspire_prompts", [os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "prompts"))], {'.txt'})
 
+# Register IPAdapter model paths for extra_model_paths.yaml support
+ipadapter_default_path = os.path.join(model_path, "ipadapter")
+utils.add_folder_path_and_extensions("ipadapter", [ipadapter_default_path], folder_paths.supported_pt_extensions)
+
+# Register CLIP vision model paths for extra_model_paths.yaml support
+clip_vision_default_path = os.path.join(model_path, "clip_vision")
+utils.add_folder_path_and_extensions("clip_vision", [clip_vision_default_path], folder_paths.supported_pt_extensions)
+
+# Register LoRA model paths for extra_model_paths.yaml support
+loras_default_path = os.path.join(model_path, "loras")
+utils.add_folder_path_and_extensions("loras", [loras_default_path], folder_paths.supported_pt_extensions)
+
 
 prompt_builder_preset = {}
 


### PR DESCRIPTION
It has been a long time since this pack was made. There have been changes to ComfyUI, bigger selection of models, as well as user knowledge and expectations.

For example, it is no longer confusing to properly select SDXL models. The current state of the pack is too restrictive, not supporting user-specified custom paths or non-hardcoded IPAdapter models, etc.

I hope to modernize this by replace preset system with manual model selection. This will break existing published workflows, but it should be trivial to just reload the node and select models again.

Replace hardcoded preset system with separate input fields for each model type
Add dynamic scanning of IPAdapter, CLIP vision, and LoRA model folders
Implement extra_model_paths.yaml support for all three model types
Remove SDXL compatibility checking to allow user flexibility (because if it's wrong, users can see real errors from downstream nodes, not an arbitrary and artificial error)
Add InsightFace boolean toggle with provider selection
Include example extra_model_paths.yaml configuration
Update documentation to reflect new dropdown-based interface
This change provides a more flexible and user-friendly interface while maintaining full compatibility with ComfyUI's model path system and custom model locations.