### PR TITLE
Ensure to pass additional arguments through api.queuePrompt (fixes "Queue Selected Nodes")

### DIFF
--- a/js/prompt.js
+++ b/js/prompt.js
@@ -270,7 +270,7 @@ app.registerExtension({
 
 
 const original_queuePrompt = api.queuePrompt;
-async function queuePrompt_with_widget_idxs(number, { output, workflow }) {
+async function queuePrompt_with_widget_idxs(number, { output, workflow }, ...args) {
 	workflow.widget_idx_map = {};
 
 	for(let i in app.graph._nodes_by_id) {
@@ -289,7 +289,7 @@ async function queuePrompt_with_widget_idxs(number, { output, workflow }) {
 		}
 	}
 
-	return await original_queuePrompt.call(api, number, { output, workflow });
+	return await original_queuePrompt.call(api, number, { output, workflow }, ...args);
 }
 
 api.queuePrompt = queuePrompt_with_widget_idxs;


### PR DESCRIPTION
`api.queuePrompt` now passes additional arguments through, including a list of selected ids to queue. 

However, this override does not pass it through, breaking the "Queue Selected Nodes" feature of ComfyUI. This PR would fix that.